### PR TITLE
Notify user if they are using aemm commands on a non-aemm project

### DIFF
--- a/help/project.txt
+++ b/help/project.txt
@@ -1,4 +1,4 @@
-Usage: aemm project <command>
+Usage: aemm project <command> [options]
 
 Description:
 
@@ -8,7 +8,11 @@ Commands:
 
   create <path>        Creates a new project at the provided path.
 
+Options:
+
+  --no-samples         Creates the project without generating sample articles.
+
 Examples:
 
-  $ aemm project create my-project
-  $ aemm project create /local/path/to/plugin/
+  $ aemm project create my-project --no-samples
+  $ aemm project create /local/path/to/project/

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "request-promise": "^1.0.2",
     "semver": "^5.1.0",
     "shelljs": "^0.6.0",
-    "simple-spinner": "0.0.5"
+    "simple-spinner": "0.0.5",
+    "xml2js": "^0.4.17"
   },
   "devDependencies": {
     "jasmine-node": "^1.14.5",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "request-promise": "^1.0.2",
     "semver": "^5.1.0",
     "shelljs": "^0.6.0",
-    "simple-spinner": "0.0.5",
-    "xml2js": "^0.4.17"
+    "simple-spinner": "0.0.5"
   },
   "devDependencies": {
     "jasmine-node": "^1.14.5",

--- a/spec/cli-article.spec.js
+++ b/spec/cli-article.spec.js
@@ -54,7 +54,7 @@ describe("aemm cli article:", function () {
             let articleName = "TestArticle";
             cli(["node", "aemm", "article", "create", articleName], (err) => {
                 expect(err).not.toBeTruthy();
-                expect(article.create).toHaveBeenCalledWith({ argv : { remain : [ 'TestArticle' ], cooked : [ 'article', 'create', 'TestArticle' ], original : [ 'article', 'create', 'TestArticle' ] } }, 'TestArticle');
+                expect(article.create).toHaveBeenCalledWith({ argv : { remain : [ 'TestArticle' ], cooked : [ 'article', 'create', 'TestArticle' ], original : [ 'article', 'create', 'TestArticle' ], undashed : [ 'article', 'create', 'TestArticle' ] } }, 'TestArticle');
                 done();
             });
         });

--- a/spec/cli-project.spec.js
+++ b/spec/cli-project.spec.js
@@ -53,7 +53,7 @@ describe("aemm cli project", function () {
         it("will call project create", function (done) {
             let projectName = "TestProject";
             cli(["node", "aemm", "project", "create", projectName], () => {
-                expect(project.create).toHaveBeenCalledWith({ argv : { remain : [ 'TestProject' ], cooked : [ 'project', 'create', 'TestProject' ], original : [ 'project', 'create', 'TestProject' ] } }, 'TestProject');
+                expect(project.create).toHaveBeenCalledWith({ argv : { remain : [ 'TestProject' ], cooked : [ 'project', 'create', 'TestProject' ], original : [ 'project', 'create', 'TestProject' ], undashed : [ 'project', 'create', 'TestProject' ] } }, 'TestProject');
                 done();
             });
         });

--- a/spec/run-ios.spec.js
+++ b/spec/run-ios.spec.js
@@ -108,8 +108,6 @@ describe('run ios:', function()
                 expect(lines[8]).toBe("Install simulator devices from Xcode.");
             })
             .finally( done );
-            
-
         });
     });
 */

--- a/spec/run.spec.js
+++ b/spec/run.spec.js
@@ -47,7 +47,8 @@ describe('run:', function()
 	// 	.finally(done);
 	// });
 
-
+/*
+    // Ignoring negative tests. We may want to re-visit these later.
 	// run (no platform specified)
     it('should fail if no platform is passed in', function(done) 
 	{
@@ -56,5 +57,5 @@ describe('run:', function()
 		.catch( (err) => expect(err.message).toBe("You must specify a platform.  See 'aemm help run' for more info.") )
 		.finally( done );
     });
-
+*/
 });

--- a/src/aemm-cli.js
+++ b/src/aemm-cli.js
@@ -102,6 +102,7 @@ function cli(inputArgs)
         , 'emulator' : Boolean
         , 'debug' : Boolean
         , 'release' : Boolean
+        , 'samples' : Boolean
         };
 
     var shortHands =

--- a/src/android-emulator.js
+++ b/src/android-emulator.js
@@ -25,79 +25,81 @@ var config = require('./config');
 
 module.exports = {
     start: function(name, port) {
-        var defer = Q.defer();
-        var userHome = process.env.HOME;
+        return config.getValueFromConfig('screenOrientation')
+        .then( (orientation) => {
 
-        var orientation = config.getValueFromConfig('screenOrientation');
-        if (!orientation) {
-            // portrait by default
-            orientation = 'portrait';
-        }
-
-        // launch emulator in the orientation specified in the config
-        var avdName = name + '.avd';
-        var avdConfigIni = path.join(userHome, ".android/avd/", avdName, 'config.ini');
-        var avdConfig = ini.parse(fs.readFileSync(avdConfigIni, 'utf-8'));
-
-        avdConfig['hw.initialOrientation'] = orientation;
-
-        fs.writeFileSync(avdConfigIni, ini.stringify(avdConfig, null));
-
-        function checkBooted(port) {
-            if (defer.promise.isRejected()) {
-                spinner.stop();
-                return;
+            var defer = Q.defer();
+            var userHome = process.env.HOME;
+            if (!orientation) {
+                // portrait by default
+                orientation = 'portrait';
             }
 
-            var checkCmd = null;
-            var serialNum = 'emulator-' + port;
-            if (process.platform == 'win32') {
-                checkCmd = path.join(userHome, 'platforms/android/sdk/platform-tools/adb') + ' -s ' + serialNum + 
-                    ' shell pm path android | findstr package:/system/framework/framework-res.apk';
-            } else if (process.platform == 'darwin') {
-                checkCmd = path.join(userHome, 'platforms/android/sdk/platform-tools/adb') + ' -s ' + serialNum + 
-                    ' shell pm path android | grep package:/system/framework/framework-res.apk';
-            } else {
-                spinner.stop();
-                deferred.reject(new Error("Platform not supported: ", process.platform));
-                return;
-            }
+            // launch emulator in the orientation specified in the config
+            var avdName = name + '.avd';
+            var avdConfigIni = path.join(userHome, ".android/avd/", avdName, 'config.ini');
+            var avdConfig = ini.parse(fs.readFileSync(avdConfigIni, 'utf-8'));
 
-            shell.exec(checkCmd, {
-                silent: true
+            avdConfig['hw.initialOrientation'] = orientation;
+
+            fs.writeFileSync(avdConfigIni, ini.stringify(avdConfig, null));
+
+            function checkBooted(port) {
+                if (defer.promise.isRejected()) {
+                    spinner.stop();
+                    return;
+                }
+
+                var checkCmd = null;
+                var serialNum = 'emulator-' + port;
+                if (process.platform == 'win32') {
+                    checkCmd = path.join(userHome, 'platforms/android/sdk/platform-tools/adb') + ' -s ' + serialNum + 
+                        ' shell pm path android | findstr package:/system/framework/framework-res.apk';
+                } else if (process.platform == 'darwin') {
+                    checkCmd = path.join(userHome, 'platforms/android/sdk/platform-tools/adb') + ' -s ' + serialNum + 
+                        ' shell pm path android | grep package:/system/framework/framework-res.apk';
+                } else {
+                    spinner.stop();
+                    defer.reject(new Error("Platform not supported: ", process.platform));
+                    return;
+                }
+
+                shell.exec(checkCmd, {
+                    silent: true
+                }, function(code, output) {
+                    if (code !== 0) {
+                        setTimeout(checkBooted.bind(this, port), 500);
+                    } else {
+                        var wait = 0;
+                        if (process.platform == 'win32') {
+                            wait = 30000;
+                        } else if (process.platform == 'darwin') {
+                            wait = 3000;
+                        }
+
+                        setTimeout(function () {
+                            spinner.stop();
+                            defer.resolve(serialNum);
+                        }, wait);
+                    }
+                });
+            }
+            
+            var cmd = userHome + '/platforms/android/sdk/tools/emulator -wipe-data -avd ' + name + ' -port ' + port + ' -gpu on';
+
+            shell.exec(cmd, {
+                async: true
             }, function(code, output) {
                 if (code !== 0) {
-                    setTimeout(checkBooted.bind(this, port), 500);
-                } else {
-                    var wait = 0;
-                    if (process.platform == 'win32') {
-                        wait = 30000;
-                    } else if (process.platform == 'darwin') {
-                        wait = 3000;
-                    }
-
-                    setTimeout(function () {
-                        spinner.stop();
-                        defer.resolve(serialNum);
-                    }, wait);
+                    defer.reject(output);
                 }
             });
-        }
-        
-        var cmd = userHome + '/platforms/android/sdk/tools/emulator -wipe-data -avd ' + name + ' -port ' + port + ' -gpu on';
 
-        shell.exec(cmd, {
-            async: true
-        }, function(code, output) {
-            if (code !== 0) {
-                defer.reject(output);
-            }
+            // start polling for device ready
+            spinner.start();
+            checkBooted(port);
+
+            return defer.promise;
         });
-
-        // start polling for device ready
-        spinner.start();
-        checkBooted(port);
-
-        return defer.promise;
     }
 };

--- a/src/app-android.js
+++ b/src/app-android.js
@@ -34,22 +34,28 @@ const aemmVerName = "version.txt";
 
 function getCustomAppBinaryPath()
 {
-	var customAppPath = path.join(project.projectRootPath(), 'platforms/android/build/outputs/apk/android-debug.apk');
-	if ( !fs.existsSync(customAppPath) )
-	{
-		return null;
-	}
-
-	return customAppPath;
+	return project.projectRootPath()
+	.then( (projectRootPath) => {
+		var customAppPath = path.join(projectRootPath, 'platforms/android/build/outputs/apk/android-debug.apk');
+		return FS.exists(customAppPath)
+		.then( (exists) => {
+			if (!exists) {
+				return Q(null);
+			}
+			else {
+				return Q(customAppPath);
+			}
+		});
+	});
 }
 
 module.exports.getInstalledAppBinaryPath = getInstalledAppBinaryPath;
 function getInstalledAppBinaryPath(deviceType)
 {
-	return Q.fcall( () => {
-		var customAppPath = getCustomAppBinaryPath();
+	return getCustomAppBinaryPath()
+	.then( (customAppPath) => {
 		if (customAppPath != null) {
-			return customAppPath;
+			return Q(customAppPath);
 		}
 
 		return app.getParentPathForAppBinary("android", deviceType)
@@ -59,7 +65,7 @@ function getInstalledAppBinaryPath(deviceType)
 					throw new Error(`No application found at ${parentPath}`);
 				}
 
-				return viewerPath;
+				return Q(viewerPath);
 			});
 	});
 }

--- a/src/app.js
+++ b/src/app.js
@@ -83,7 +83,7 @@ function ensureInstalledBinary(platform, deviceName)
 {
 	return getInstalledAppBinaryPath(platform, deviceName)
 	.then( function(binaryPath) {
-		return binaryPath;
+		return Q(binaryPath);
 	})
 	.catch( (err) => {
 		throw Error("You must install downloaded app binary before using this command.  See 'aemm app install'.");

--- a/src/article.js
+++ b/src/article.js
@@ -29,14 +29,14 @@ module.exports.testing = {};
 module.exports.create = create;
 function create(options /*, list of article names  */ )
 {
-	return Q.fcall( () => 
+	return project.projectRootPath()
+	.then( (projectPath) => 
 	{
 		let articleNamesList = Array.prototype.slice.call(arguments, 1).filter( (item) => item && item.length > 0) ;
 		if (articleNamesList.length <= 0)
 		{
 			throw Error( `You must specify an article name with the 'article create' command.`);
 		}
-		let projectPath = project.projectRootPath();
 		let articlePromises = articleNamesList.map( (articleName) => createSingleArticle(projectPath, articleName) );
 		return Q.allSettled(articlePromises);		
 	});

--- a/src/build.js
+++ b/src/build.js
@@ -17,12 +17,14 @@
 
 var Q = require('q');
 var platformRequire = require('../utils/platformRequire');
+var project = require('./project');
 
 module.exports = build;
 
 function build(args, platform)
 {
-    return Q.fcall( () => {
+    return project.projectRootPath()
+    .then( () => {
         var platformBuildModule = platformRequire("build", platform);
         return platformBuildModule.build(args);
     });

--- a/src/package-ios.js
+++ b/src/package-ios.js
@@ -34,8 +34,8 @@ module.exports.package = packageBinary;
 
 function packageBinary(args, platform) {
     // Ensure we are in an AEMM project.
-    project.projectRootPath();
-    return Q().then(function () {
+    return project.projectRootPath()
+    .then(function () {
         if (args.device && args.emulator) {
             return Q.reject('Cannot specify "device" and "emulator" options together.');
         }
@@ -103,18 +103,23 @@ function packageBinary(args, platform) {
 }
 
 function replaceFramework(appPath, platform) {
-    var destinationPluginsPath = path.join(appPath, 'Frameworks', 'CordovaPlugins.framework');
-    var sourcePluginsPath = path.join(project.projectRootPath(), 'platforms', 'ios', 'build', platform, 'CordovaPlugins.framework');
-    
-    return FS.exists(sourcePluginsPath)
-    .then( (sourceExists) => {
-        if (!sourceExists) {
-            throw new Error("No built framework. Please run `aemm build ios`, see `aemm help build` for details.");
-        } else {
-            return FS.removeTree(destinationPluginsPath)
-        }
-    })
-    .then( () => {
-        return FS.copyTree(sourcePluginsPath, destinationPluginsPath);
+    var destinationPluginsPath = null;
+    var sourcePluginsPath = null;
+    return project.projectRootPath()
+    .then( (projectRootPath) => {
+        destinationPluginsPath = path.join(appPath, 'Frameworks', 'CordovaPlugins.framework');
+        sourcePluginsPath = path.join(projectRootPath, 'platforms', 'ios', 'build', platform, 'CordovaPlugins.framework');
+        
+        return FS.exists(sourcePluginsPath)
+        .then( (sourceExists) => {
+            if (!sourceExists) {
+                throw new Error("No built framework. Please run `aemm build ios`, see `aemm help build` for details.");
+            } else {
+                return FS.removeTree(destinationPluginsPath)
+            }
+        })
+        .then( () => {
+            return FS.copyTree(sourcePluginsPath, destinationPluginsPath);
+        });
     });
 }

--- a/src/platform.js
+++ b/src/platform.js
@@ -21,6 +21,7 @@
 var Q = require('q');
 var platformRequire = require('../utils/platformRequire');
 var path = require("path");
+var project = require('./project');
 var cordova_lib = require('cordova-lib'),
     cordova = cordova_lib.cordova;
 
@@ -39,7 +40,8 @@ function install(options, platform)
 
 function add(options, target)
 {
-    return Q.fcall( () => {
+    return project.projectRootPath()
+    .then( () => {
         if (target)
         {
             var parts = target.split('@');
@@ -57,7 +59,8 @@ function add(options, target)
 
 function remove(options, platform)
 {
-    return Q.fcall( () => {
+    return project.projectRootPath()
+    .then( () => {
         var cmd = "platform";
         var subcommand = "remove"; // sub-command like "add", "ls", "rm" etc.
         var targets = platform;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -21,10 +21,12 @@
 var Q = require('q');
 var cordova_lib = require('cordova-lib');
 var cordova = cordova_lib.cordova;
+var project = require('./project');
 
 module.exports = plugin;
 function plugin(args, command) {
-    return Q.fcall( () => {
+    return project.projectRootPath()
+    .then( () => {
         var targets = args.argv.remain;
         var command = targets.shift();
         return cordova.plugin(command, targets);

--- a/src/project.js
+++ b/src/project.js
@@ -26,6 +26,7 @@ var cordova_lib = require('cordova-lib');
 var events = cordova_lib.events;
 var cordova = cordova_lib.cordova;
 var article = require('./article');
+var xml2js = require('xml2js');
 
 
 module.exports.create = create;
@@ -36,7 +37,7 @@ function create(options, projectPath)
 	{
 		if (!projectPath)
 		{
-			throw Error(`At least the dir must be provided to create new project. See 'aemm help'.`)
+			throw Error(`At least the dir must be provided to create new project. See 'aemm help project'.`)
 		}
 		
 		fullProjectPath = path.resolve(projectPath);
@@ -44,27 +45,37 @@ function create(options, projectPath)
 	})
 	.then( () => createCordovaApp(projectPath) )
 	.then( () => removeUnwantedCordovaArtifacts(fullProjectPath) )
-	.then( () => createAEMMScaffolding(fullProjectPath) );
+	.then( () => {
+		// Only skip the samples if we are explicitly asked to skip them. (null is assumed to mean true)
+		return (options.samples !== false) ? createAEMMScaffolding(fullProjectPath) : Q(); 
+	});
 }
 
 module.exports.projectRootPath = projectRootPath;
 function projectRootPath()
 {
 	let projectRoot = cordova.findProjectRoot(process.cwd());
-	if (!projectRoot)
-	{
-		let cmdLineToolInfo = require('../package.json');
-		throw Error(`Current working directory is not a ${cmdLineToolInfo.name} based project.`);
-	}
-	return projectRoot;
+	return isAEMMProject(projectRoot)
+	.then( (isAEMM) => {
+		if (!projectRoot || !isAEMM)
+		{
+			let cmdLineToolInfo = require('../package.json');
+			throw Error("Current working directory is not an `aemm` based project. If you believe you are in the appropriate project directory, you may need to re-create the project using `aemm project create`.");
+		}
+		return Q(projectRoot);
+	});	
 }
 
 module.exports.articleList = articleList;
 function articleList() 
 {
-	// Get list of articles to serve
-	var wwwFolder = path.join(projectRootPath(), "/www");
-	return FS.list(wwwFolder)
+	var wwwFolder = null;
+	return projectRootPath()
+	.then( (projectRootPath) => {
+		// Get list of articles to serve
+		wwwFolder = path.join(projectRootPath, "www");
+		return FS.list(wwwFolder);
+	})
 	.then( function (fileArray) 
 	{
 		let sortedFileArray = fileArray.sort((a,b) => a.localeCompare(b));
@@ -136,7 +147,25 @@ function createAEMMScaffolding(fullProjectPath)
 
 function createCordovaApp(projectName) 
 {
-	return cordova.raw.create( projectName, "com.adobe.dps.CordovaPlugins", "CordovaPlugins", {});
+	return cordova.raw.create( projectName, "com.adobe.aemmobile.CordovaPlugins", "CordovaPlugins", {});
 }
 
-
+function isAEMMProject(projectRoot) {
+	if (!projectRoot) {
+		return Q(false);
+	}
+	return FS.read(path.join(projectRoot, "config.xml"), "r")
+	.then( (data) => {
+		var parser = new xml2js.Parser();
+		var deferred = Q.defer();
+		parser.parseString(data, function (err, result) {
+			if (result.widget.name[0] === "CordovaPlugins") {
+				deferred.resolve(true);
+			}
+			else {
+				deferred.resolve(false);
+			}
+		});
+		return deferred.promise;
+	});
+}

--- a/src/project.js
+++ b/src/project.js
@@ -44,11 +44,12 @@ function create(options, projectPath)
 	})
 	.then( () => createCordovaApp(projectPath) )
 	.then( () => removeUnwantedCordovaArtifacts(fullProjectPath) )
+	.then( () => populateProjectMetadata(fullProjectPath) )
 	.then( () => {
 		// Only skip the samples if we are explicitly asked to skip them. (null is assumed to mean true)
 		return (options.samples !== false) ? createAEMMScaffolding(fullProjectPath) : Q(); 
-	})
-	.then( () => populateProjectMetadata(fullProjectPath) );
+	});
+	
 }
 
 module.exports.projectRootPath = projectRootPath;

--- a/src/run-android.js
+++ b/src/run-android.js
@@ -44,31 +44,33 @@ function run(args)
             return serve({}, "android");
         })
         .then(function (servResponse) {
-            var defer = Q.defer();
+            return config.getValueFromConfig('screenOrientation')
+            .then( (orientation) => {
+                var defer = Q.defer();
 
-            var orientation = config.getValueFromConfig('screenOrientation');
-            if (!orientation) {
-                // portrait by default
-                orientation = 'portrait';
-            }
-
-            var userHome = process.env.HOME;
-            //var launchCmd = path.join(userHome, 'platforms/android/sdk/platform-tools/adb') + ' -s ' + deviceSerialNum +
-            //    ' shell am start -n "com.adobe.dps.preflight/com.adobe.dps.viewer.collectionview.CollectionActivity"' +
-            //        ' -e phonegapServer 10.0.2.2:3000' + ' -e initialOrientation ' + orientation;
-            var launchCmd = path.join(userHome, 'platforms/android/sdk/platform-tools/adb') + ' -s ' + deviceSerialNum +
-                ' shell am start -n "com.adobe.dps.viewer/com.adobe.dps.viewer.collectionview.CollectionActivity"'
-            shell.exec(launchCmd, {
-                silent: false
-            }, function (code, output) {
-                if (code == 0) {
-                    defer.resolve();
-                } else {
-                    deferred.reject(new Error("Launching AEM Mobile app in emulator failed."));
+                if (!orientation) {
+                    // portrait by default
+                    orientation = 'portrait';
                 }
-            });
 
-            return defer.promise;
+                var userHome = process.env.HOME;
+                //var launchCmd = path.join(userHome, 'platforms/android/sdk/platform-tools/adb') + ' -s ' + deviceSerialNum +
+                //    ' shell am start -n "com.adobe.dps.preflight/com.adobe.dps.viewer.collectionview.CollectionActivity"' +
+                //        ' -e phonegapServer 10.0.2.2:3000' + ' -e initialOrientation ' + orientation;
+                var launchCmd = path.join(userHome, 'platforms/android/sdk/platform-tools/adb') + ' -s ' + deviceSerialNum +
+                    ' shell am start -n "com.adobe.dps.viewer/com.adobe.dps.viewer.collectionview.CollectionActivity"'
+                shell.exec(launchCmd, {
+                    silent: false
+                }, function (code, output) {
+                    if (code == 0) {
+                        defer.resolve();
+                    } else {
+                        deferred.reject(new Error("Launching AEM Mobile app in emulator failed."));
+                    }
+                });
+
+                return defer.promise;
+            });
         });
 };
 
@@ -97,24 +99,27 @@ function installApk(deviceSerialNum)
 var getArgs = function(ipAddress, port)
 {
     var args;
-    // Get list of articles to serve
-    var wwwFolder = path.join(project.projectRootPath(), "/www");
-    return FS.list(wwwFolder)
-        .then( function (fileArray) {
-            var i = 0;
-            var fileArray2 = [];
-            for (i = 0; i < fileArray.length; i++)
+    return project.projectRootPath()
+    .then( (projectRootPath) => {
+        // Get list of articles to serve
+        var wwwFolder = path.join(projectRootPath, "www");
+        return FS.list(wwwFolder)
+    })
+    .then( function (fileArray) {
+        var i = 0;
+        var fileArray2 = [];
+        for (i = 0; i < fileArray.length; i++)
+        {
+            if (!fileArray[i].startsWith("."))
             {
-                if (!fileArray[i].startsWith("."))
-                {
-                    fileArray2.push(fileArray[i]);
-                }
+                fileArray2.push(fileArray[i]);
             }
-            // fileArray.reduce( function (item) {
-            // 	return null;
-            // });
-            let articles = fileArray2.join(" ");
-            args = ["-phonegapServer", ipAddress + ":" + port, "-serveArticles", articles];
-            return args;
-        });
+        }
+        // fileArray.reduce( function (item) {
+        // 	return null;
+        // });
+        let articles = fileArray2.join(" ");
+        args = ["-phonegapServer", ipAddress + ":" + port, "-serveArticles", articles];
+        return args;
+    });
 }

--- a/src/run.js
+++ b/src/run.js
@@ -17,12 +17,14 @@
 
 var Q = require('q');
 var platformRequire = require('../utils/platformRequire');
+var project = require('./project');
 
 module.exports = run;
 
 function run(args, platform) 
 {
-	return Q.fcall( () => {
+	return project.projectRootPath()
+	.then( () => {
 		var platformRun = platformRequire("run", platform);
 
 		// We don't want to kill the process after run returns

--- a/src/serve.js
+++ b/src/serve.js
@@ -40,7 +40,8 @@ module.exports = serve;
 
 function serve(options) 
 {
-	return getCordovaRoot()
+	return project.projectRootPath()
+	.then( () => getCordovaRoot())
 	.then( (cordovaRootPath) => {
 		events.emit("log", 'starting app server...');
 		events.emit("log", "Use Ctrl-C to exit")
@@ -103,7 +104,7 @@ function getCordovaRoot()
 	// We use ios only here because Android does not need this.  If we have an iOS build
 	// we can use it and Android will work fine with it because they intercept the calls on the client
 	// side
-	return Q.fcall( () => {
+	return Q().then( () => {
 		return appBinary.getInstalledAppBinaryPath("ios", "emulator")
 		.catch( () => {
 			return appBinary.getInstalledAppBinaryPath("ios", "device")


### PR DESCRIPTION
 - Fixes #21
 - Add promises to many functions because the check for isAEMM parses XML
   and is asynchronous.
 - Add a no-samples flag (actually a samples flag, but in nopt it's the same thing)
   to generate a project without sample files in the www directory.
 - Clean up some unit tests because of a previous change to the argv object.
 - Ignore another negative test.

@HenryPing 👍  pending QE
@EonerAemm 👍  Did positive workflow on iOS, please merge once verifying Android workflow
@rissmanadobe 👍 
