### PR TITLE
Set minimum node version to 6.2.2

### DIFF
--- a/bin/aemm.js
+++ b/bin/aemm.js
@@ -18,12 +18,13 @@
 
 var semver = require('semver');
 var engines = require('../package').engines;
+var logger = require('cordova-common').CordovaLogger.get();
 
 // Check node version		
 if (!semver.satisfies(process.version, engines["node"]))
 {
-	throw new Error("Invalid Node.js version(" + process.version + ").  AEMM requires " + engines["node"] + "\n");
-	process.exit(1);
+    logger.error("Invalid Node.js version(" + process.version + ").  AEMM requires Node.js version(" + engines["node"] + ")");
+    process.exit(1);
 }
 
 var cli = require('../src/aemm-cli');

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jshint": "^2.9.2"
   },
   "engines": {
-    "node": ">=4.1.0"
+    "node": ">=6.2.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - Fixes #31
 - Improve error output if node version is lower than minimum required.