### PR TITLE
Provide aemm error instead of cordova error

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -25,6 +25,13 @@ function build(args, platform)
     return Q.fcall( () => {
         var platformBuildModule = platformRequire("build", platform);
         return platformBuildModule.build(args);
+    }).catch( (err) => {
+        if (err.message == "No platforms added to this project. Please use `cordova platform add <platform>`.") {
+            throw new Error("No platforms added to this project. Please use `aemm platform add <platform>`.");
+        }
+        else {
+            throw err;
+        }
     });
 };
 


### PR DESCRIPTION
 - Fixes #29
 - When build is requested but no platforms added, intercept the error and
   provide an aemm-specific error instead of a cordova-specific error.

@EonerAemm 