### PR TITLE
Install core AEM Mobile plugins after `platform add ios`

### DIFF
--- a/src/platform-ios.js
+++ b/src/platform-ios.js
@@ -54,6 +54,16 @@ function add(spec)
 		var target = spec ? target_repo + "@" + spec : target_repo; 
         return cordova.raw.platform("add", target);
     })
+    .then( () => {
+		events.emit("info", "Ensuring core AEM Mobile plugins are installed.");
+        var targets = [
+			"aemm-plugin-navto",
+			"aemm-plugin-inappbrowser",
+			"aemm-plugin-fullscreen-video",
+			"aemm-plugin-html-contract"
+			];
+        return cordova.raw.plugin("add", targets);
+    })
 	.then( function () {
 		events.emit("results", "Finished installing ios platform.");	
 	});


### PR DESCRIPTION
 - Fixes #28
 - Installs navto, inappbrowser, fullscreen-video, and html-contract

@HenryPing @EonerAemm 