### PR TITLE
Bump ios-sim dependency to latest released version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cross-spawn-async": "^2.1.9",
     "decompress-zip": "^0.2.0",
     "ini": "^1.3.4",
-    "ios-sim": "5.0.8",
+    "ios-sim": "6.1.2",
     "ip": "^1.1.3",
     "jsonfile": "^2.2.3",
     "lodash": "^4.6.1",


### PR DESCRIPTION
- this version bump enables the `aemm run ios --list` command to return the set of Simulators that are included with Xcode 9:
```
Available ios virtual devices
iPhone-5s, 11.0
iPhone-6, 11.0
iPhone-6-Plus, 11.0
iPhone-6s, 11.0
iPhone-6s-Plus, 11.0
iPhone-7, 11.0
iPhone-7-Plus, 11.0
iPhone-SE, 11.0
iPhone-8, 11.0
iPhone-8-Plus, 11.0
iPhone-X, 11.0
iPad-Air, 11.0
iPad-Air-2, 11.0
iPad--5th-generation-, 11.0
iPad-Pro--9-7-inch-, 11.0
iPad-Pro, 11.0
iPad-Pro--12-9-inch---2nd-generation-, 11.0
iPad-Pro--10-5-inch-, 11.0
```